### PR TITLE
Change some wording in settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,12 +81,12 @@
     <string name="pref_hls_audio_bitrate_title">Audio Bitrate</string>
     <string name="pref_hls_audio_bitrate_default">64000</string>
     <string name="pref_default_player">Default Player</string>
-    <string name="pref_internal_player">Use Internal Player</string>
-    <string name="pref_external_player_override_video">Override External Player for Videos</string>
-    <string name="pref_internal_player_summary_on">Use MythTV Player Internal Player</string>
+    <string name="pref_internal_player">Internal Player</string>
+    <string name="pref_external_player_override_video">External Player for Videos</string>
+    <string name="pref_internal_player_summary_on">Playback will be handled by the Internal Player</string>
     <string name="pref_internal_player_summary_off">Playback will be handled by an External Player</string>
-    <string name="pref_external_player_override_video_summary_on">Video will be played in an External Player</string>
-    <string name="pref_external_player_override_video_summary_off">Video will be played by the Internal Player</string>
+    <string name="pref_external_player_override_video_summary_on">Videos will be played by an External Player</string>
+    <string name="pref_external_player_override_video_summary_off">Videos will be played by the Internal Player</string>
     <string name="pref_hls_video_width_title_summary">HLS transcode video width</string>
     <string name="pref_hls_video_height_title_summary">HLS transcode video height</string>
     <string name="pref_hls_video_bitrate_title_summary">HLS transcode video bitrate</string>


### PR DESCRIPTION
This would make it more clear and easier to read

Internal Player <off>
Playback will be handled by an External Player

Internal Player <on>
Playback will be handled by the Internal Player

External Player for Videos <off>
Videos will be played by the Internal Player

External Player for Videos <on>
Videos will be played by an External Player