### PR TITLE
Update short description to be within correct length

### DIFF
--- a/metadata/de-DE/short_description.txt
+++ b/metadata/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Greifen Sie mit MythTV-Player, zu Hause oder von unterwegs, auf Ihre MythTV Inhalte zu
+Greifen Sie mit MythTV-Player auf Ihre MythTV Inhalte zu


### PR DESCRIPTION
Google Play Store Listing dictates the Short Description
can be a maximum of 80 characters.

fixes #177