### PR TITLE
Add filter to only show HLS recordings and videos

### DIFF
--- a/app/src/main/java/org/mythtv/android/domain/SettingsKeys.java
+++ b/app/src/main/java/org/mythtv/android/domain/SettingsKeys.java
@@ -31,6 +31,8 @@ public class SettingsKeys {
     public static final String KEY_PREF_BACKEND_URL = "backend_url";
     public static final String KEY_PREF_BACKEND_PORT = "backend_port";
 
+    public static final String KEY_PREF_FILTER_HLS_ONLY = "filter_hls_only";
+
     public static final String KEY_PREF_INTERNAL_PLAYER = "internal_player";
     public static final String KEY_PREF_SHOW_ADULT_TAB = "show_adult_tab";
 

--- a/app/src/main/java/org/mythtv/android/presentation/utils/Utils.java
+++ b/app/src/main/java/org/mythtv/android/presentation/utils/Utils.java
@@ -158,6 +158,7 @@ public class Utils {
 
         List<MediaItemModel> mediaItems = new ArrayList<>();
 
+        boolean filterHlsOnlyPreference = sharedPreferences.getBoolean( SettingsKeys.KEY_PREF_FILTER_HLS_ONLY, false );
         boolean filterByGroup = sharedPreferences.getBoolean(SettingsKeys.KEY_PREF_ENABLE_RECORDING_GROUP_FILTER, false);
         String filterGroup = sharedPreferences.getString(SettingsKeys.KEY_PREF_RECORDING_GROUP_FILTER, "");
         Log.d(TAG, "filter : filterByGroup=" + filterByGroup + ", filterGroup=" + filterGroup);
@@ -196,6 +197,18 @@ public class Utils {
 
                     continue;
 
+                } else if( filterHlsOnlyPreference ) {
+
+                    if( mediaItemModel.getLiveStreamId() > 0) {
+
+                        filtered = true;
+
+                    } else {
+
+                        continue;
+
+                    }
+
                 } else {
 
                     filtered = true;
@@ -203,6 +216,16 @@ public class Utils {
                 }
 
             } else {
+
+                if( filterHlsOnlyPreference ) {
+
+                    if( mediaItemModel.getLiveStreamId() <= 0) {
+
+                        continue;
+
+                    }
+
+                }
 
                 if (filterByParentalLevel && mediaItemModel.getParentalLevel() > parentalLevel) {
                     Log.d(TAG, "filter : does not meet parental level, skipping...");

--- a/app/src/main/java/org/mythtv/android/presentation/view/activity/phone/AbstractBasePhoneActivity.java
+++ b/app/src/main/java/org/mythtv/android/presentation/view/activity/phone/AbstractBasePhoneActivity.java
@@ -198,6 +198,8 @@ public abstract class AbstractBasePhoneActivity extends AppCompatActivity implem
                     return true;
                 }
 
+                break;
+
         }
 
         return super.onOptionsItemSelected( item );

--- a/app/src/main/java/org/mythtv/android/presentation/view/activity/tv/SettingsActivity.java
+++ b/app/src/main/java/org/mythtv/android/presentation/view/activity/tv/SettingsActivity.java
@@ -71,21 +71,23 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
     private static final int MASTER_BACKEND_PORT = 12;
     private static final int PLAYER_SETTINGS = 20;
     private static final int INTERNAL_PLAYER_SETTINGS = 21;
-    private static final int RECORDING_SETTINGS = 30;
-    private static final int ENABLE_RECORDING_GROUP = 31;
-    private static final int RECORDING_GROUPS_FILTER = 32;
-    private static final int VIDEO_SETTINGS = 40;
-    private static final int ADULT_SETTINGS = 41;
-    private static final int PARENTAL_CONTROLS = 42;
-    private static final int PARENTAL_CONTROL_LEVEL = 43;
-    private static final int CONTENT_RATINGS = 44;
-    private static final int CONTENT_RATING_NR = 45;
-    private static final int CONTENT_RATING_G = 46;
-    private static final int CONTENT_RATING_PG = 47;
-    private static final int CONTENT_RATING_PG13 = 48;
-    private static final int CONTENT_RATING_R = 49;
-    private static final int CONTENT_RATING_NC17 = 50;
-    private static final int ANALYTICS_SETTINGS = 60;
+    private static final int FILTER_SETTINGS = 30;
+    private static final int FILTER_HLS_ONLY = 31;
+    private static final int RECORDING_SETTINGS = 40;
+    private static final int ENABLE_RECORDING_GROUP = 41;
+    private static final int RECORDING_GROUPS_FILTER = 42;
+    private static final int VIDEO_SETTINGS = 50;
+    private static final int ADULT_SETTINGS = 51;
+    private static final int PARENTAL_CONTROLS = 52;
+    private static final int PARENTAL_CONTROL_LEVEL = 53;
+    private static final int CONTENT_RATINGS = 54;
+    private static final int CONTENT_RATING_NR = 55;
+    private static final int CONTENT_RATING_G = 56;
+    private static final int CONTENT_RATING_PG = 57;
+    private static final int CONTENT_RATING_PG13 = 58;
+    private static final int CONTENT_RATING_R = 59;
+    private static final int CONTENT_RATING_NC17 = 60;
+    private static final int ANALYTICS_SETTINGS = 70;
 
     private static final int OPTION_CHECK_SET_ID = 10;
 
@@ -97,6 +99,9 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
 
     private static PlayerFragment mPlayerFragment;
     private static InternalPlayerFragment mInternalPlayerFragment;
+
+    private static FilterSettingsFragment mFilterSettingsFragment;
+    private static EnableHlsOnlyFilterFragment mEnableHlsOnlyFilterFragment;
 
     private static RecordingSettingsFragment mRecordingSettingsFragment;
     private static EnableRecordingGroupFragment mEnableRecordingGroupFragment;
@@ -142,6 +147,9 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
 
         mPlayerFragment = new PlayerFragment();
         mInternalPlayerFragment = new InternalPlayerFragment();
+
+        mFilterSettingsFragment = new FilterSettingsFragment();
+        mEnableHlsOnlyFilterFragment = new EnableHlsOnlyFilterFragment();
 
         mRecordingSettingsFragment = new RecordingSettingsFragment();
         mEnableRecordingGroupFragment = new EnableRecordingGroupFragment();
@@ -223,6 +231,12 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
 
                     break;
 
+                case FILTER_SETTINGS :
+
+                    GuidedStepFragment.add( fm, mFilterSettingsFragment, android.R.id.content );
+
+                    break;
+
                 case RECORDING_SETTINGS:
 
                     GuidedStepFragment.add( fm, mRecordingSettingsFragment, android.R.id.content );
@@ -259,8 +273,8 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
 
             String playback = ( internalPlayer ? getResources().getString( R.string.pref_internal_player_summary_on ) : getResources().getString( R.string.pref_internal_player_summary_off ) );
 
-            boolean showAdultContent = getShowAdultContent( getActivity() );
-            String content = ( showAdultContent ? getResources().getString( R.string.pref_show_adult_tab_summary_on ) : getResources().getString( R.string.pref_show_adult_tab_summary_off ) );
+            boolean enableHlsOnly = getFilterHlsOnly( getActivity() );
+            String hlsOnly = ( enableHlsOnly ? getResources().getString( R.string.pref_filter_hls_only_summary_on ) : getResources().getString( R.string.pref_filter_hls_only_summary_off ) );
 
             boolean enableAnalytics = getEnableAnalytics( getActivity() );
             String analytics = ( enableAnalytics ? getResources().getString( R.string.pref_enable_analytics_summary_on ) : getResources().getString( R.string.pref_enable_analytics_summary_off ) );
@@ -272,6 +286,10 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
             addAction( getActivity(), actions, PLAYER_SETTINGS,
                     getResources().getString( R.string.pref_default_player ),
                     playback,
+                    true, true );
+            addAction( getActivity(), actions, FILTER_SETTINGS,
+                    getResources().getString( R.string.pref_filter_hls_only_title ),
+                    hlsOnly,
                     true, true );
             addAction( getActivity(), actions, RECORDING_SETTINGS,
                     getResources().getString( R.string.recording_preferences ),
@@ -606,6 +624,127 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
                     getResources().getString( R.string.tv_settings_no ),
                     null,
                     !internalPlayer );
+
+            setActions( actions );
+
+        }
+
+    }
+
+    public static class FilterSettingsFragment extends GuidedStepFragment {
+
+        @NonNull
+        @Override
+        public GuidanceStylist.Guidance onCreateGuidance( Bundle savedInstanceState ) {
+
+            String title = getResources().getString( R.string.pref_filter_hls_only_title );
+            String breadcrumb = getResources().getString( R.string.title_activity_settings );
+            String description = "";
+            Drawable icon = null;
+
+            return new GuidanceStylist.Guidance( title, description, breadcrumb, icon );
+        }
+
+        @Override
+        public void onCreateActions( @NonNull List<GuidedAction> actions, Bundle savedInstanceState ) {
+
+            updateActions( actions );
+
+        }
+
+        @Override
+        public void onGuidedActionClicked( GuidedAction action ) {
+
+            FragmentManager fm = getFragmentManager();
+
+            Log.d( TAG, "onGuidedActionClicked : action=" + action );
+            switch( (int) action.getId() ) {
+
+                case FILTER_HLS_ONLY :
+
+                    GuidedStepFragment.add( fm, mEnableHlsOnlyFilterFragment, android.R.id.content );
+
+                    break;
+
+            }
+
+        }
+
+        public void updateActions( List<GuidedAction> actions ) {
+
+            if( null == actions ) {
+
+                actions = new ArrayList<>();
+
+            }
+
+            String hlsOnly = ( getFilterHlsOnly( getActivity() ) ? getResources().getString( R.string.pref_filter_hls_only_summary_on ) : getResources().getString( R.string.pref_filter_hls_only_summary_off ) );
+
+            addAction( getActivity(), actions, FILTER_HLS_ONLY,
+                    getResources().getString( R.string.pref_filter_hls_only ),
+                    hlsOnly,
+                    true, true );
+
+            setActions( actions );
+
+        }
+
+    }
+
+    public static class EnableHlsOnlyFilterFragment extends GuidedStepFragment {
+
+        @NonNull
+        @Override
+        public GuidanceStylist.Guidance onCreateGuidance( Bundle savedInstanceState ) {
+
+            String title = getResources().getString( R.string.pref_filter_hls_only );
+            String breadcrumb = getResources().getString( R.string.title_activity_settings ) + " | " + getResources().getString( R.string.pref_filter_hls_only_title );
+            String description = ""; //getResources().getString( R.string.tv_settings_playback_internal_player_description );
+            Drawable icon = null;
+
+            return new GuidanceStylist.Guidance( title, description, breadcrumb, icon );
+        }
+
+        @Override
+        public void onCreateActions( @NonNull List<GuidedAction> actions, Bundle savedInstanceState ) {
+
+            updateActions( actions );
+        }
+
+        @Override
+        public void onGuidedActionClicked( GuidedAction action ) {
+            Log.d( TAG, "onGuidedActionClicked : action=" + action );
+
+            boolean updated = ( action.getLabel1().equals( getResources().getString( R.string.tv_settings_yes ) ) );
+            putBooleanToPreferences( getActivity(), SettingsKeys.KEY_PREF_FILTER_HLS_ONLY, updated );
+
+            mSettingsFragment.updateActions( null );
+            mFilterSettingsFragment.updateActions( null );
+
+            getFragmentManager().popBackStack();
+
+        }
+
+        public void updateActions( List<GuidedAction> actions ) {
+
+            if( null == actions ) {
+
+                actions = new ArrayList<>();
+
+            }
+
+            boolean hlsOnly = getFilterHlsOnly( getActivity() );
+
+            addCheckedAction( getActivity(), actions,
+                    -1,
+                    getResources().getString( R.string.tv_settings_yes ),
+                    null,
+                    hlsOnly );
+            addCheckedAction( getActivity(), actions,
+                    -1,
+                    getResources().getString( R.string.tv_settings_no ),
+                    null,
+                    !hlsOnly );
 
             setActions( actions );
 
@@ -1890,6 +2029,11 @@ public class SettingsActivity extends AbstractBaseTvActivity implements HasCompo
     private static boolean getShouldUseInternalPlayer( Context context ) {
 
         return getBooleanFromPreferences( context, SettingsKeys.KEY_PREF_INTERNAL_PLAYER );
+    }
+
+    private static boolean getFilterHlsOnly( Context context ) {
+
+        return getBooleanFromPreferences( context, SettingsKeys.KEY_PREF_FILTER_HLS_ONLY );
     }
 
     private static boolean getEnableRecordingGroupFilter( Context context ) {

--- a/app/src/main/java/org/mythtv/android/presentation/view/component/EmptyRecyclerView.java
+++ b/app/src/main/java/org/mythtv/android/presentation/view/component/EmptyRecyclerView.java
@@ -1,0 +1,86 @@
+package org.mythtv.android.presentation.view.component;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+import org.mythtv.android.R;
+import org.mythtv.android.domain.SettingsKeys;
+
+/**
+ * @author dmfrey
+ *         <p>
+ *         Created on 2/19/17.
+ */
+
+public class EmptyRecyclerView extends RecyclerView {
+
+    private View emptyView;
+
+    final private AdapterDataObserver observer = new AdapterDataObserver() {
+        @Override
+        public void onChanged() {
+            checkIfEmpty();
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            checkIfEmpty();
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            checkIfEmpty();
+        }
+    };
+
+    public EmptyRecyclerView(Context context) {
+        super(context);
+    }
+
+    public EmptyRecyclerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public EmptyRecyclerView(Context context, AttributeSet attrs,
+                             int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    void checkIfEmpty() {
+        if (emptyView != null && getAdapter() != null) {
+            final boolean emptyViewVisible = getAdapter().getItemCount() == 0;
+            emptyView.setVisibility(emptyViewVisible ? VISIBLE : GONE);
+            setVisibility(emptyViewVisible ? GONE : VISIBLE);
+
+            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences( getContext() );
+            boolean showHlsOnly = sharedPreferences.getBoolean( SettingsKeys.KEY_PREF_FILTER_HLS_ONLY, false );
+            TextView hlsOnlyView = (TextView) emptyView.findViewById( R.id.hls_only_view );
+            hlsOnlyView.setVisibility( showHlsOnly ? View.VISIBLE : View.GONE );
+        }
+    }
+
+    @Override
+    public void setAdapter(Adapter adapter) {
+        final Adapter oldAdapter = getAdapter();
+        if (oldAdapter != null) {
+            oldAdapter.unregisterAdapterDataObserver(observer);
+        }
+        super.setAdapter(adapter);
+        if (adapter != null) {
+            adapter.registerAdapterDataObserver(observer);
+        }
+
+        checkIfEmpty();
+    }
+
+    public void setEmptyView(View emptyView) {
+        this.emptyView = emptyView;
+        checkIfEmpty();
+    }
+
+}

--- a/app/src/main/java/org/mythtv/android/presentation/view/fragment/phone/MediaItemListFragment.java
+++ b/app/src/main/java/org/mythtv/android/presentation/view/fragment/phone/MediaItemListFragment.java
@@ -21,7 +21,6 @@ package org.mythtv.android.presentation.view.fragment.phone;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -37,6 +36,7 @@ import org.mythtv.android.presentation.view.MediaItemListView;
 import org.mythtv.android.presentation.view.activity.phone.TroubleshootClickListener;
 import org.mythtv.android.presentation.view.adapter.phone.LayoutManager;
 import org.mythtv.android.presentation.view.adapter.phone.MediaItemsAdapter;
+import org.mythtv.android.presentation.view.component.EmptyRecyclerView;
 import org.mythtv.android.presentation.view.listeners.MediaItemListListener;
 import org.mythtv.android.presentation.view.listeners.NotifyListener;
 
@@ -79,7 +79,10 @@ public class MediaItemListFragment extends AbstractBaseFragment implements Media
     MediaItemListPresenter mediaItemListPresenter;
 
     @BindView( R.id.rv_mediaItems )
-    RecyclerView rv_mediaItems;
+    EmptyRecyclerView rv_mediaItems;
+
+    @BindView( R.id.media_item_empty_list_view )
+    View emptyView;
 
     private Unbinder unbinder;
 
@@ -334,7 +337,6 @@ public class MediaItemListFragment extends AbstractBaseFragment implements Media
         setupUI();
 
         this.initialize();
-        this.loadMediaItemList();
 
         Log.d( TAG, "onActivityCreated : exit" );
     }
@@ -345,6 +347,7 @@ public class MediaItemListFragment extends AbstractBaseFragment implements Media
         super.onResume();
 
         this.mediaItemListPresenter.resume();
+        this.loadMediaItemList();
 
         Log.d( TAG, "onResume : exit" );
     }
@@ -399,6 +402,7 @@ public class MediaItemListFragment extends AbstractBaseFragment implements Media
         this.mediaItemsAdapter = new MediaItemsAdapter( getActivity(), new ArrayList<>() );
         this.mediaItemsAdapter.setOnItemClickListener( onItemClickListener );
         this.rv_mediaItems.setAdapter( mediaItemsAdapter );
+        this.rv_mediaItems.setEmptyView( emptyView );
 
         Log.d( TAG, "setupUI : exit" );
     }

--- a/app/src/main/res/layout/fragment_media_item_list.xml
+++ b/app/src/main/res/layout/fragment_media_item_list.xml
@@ -22,13 +22,37 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.RecyclerView
+    <org.mythtv.android.presentation.view.component.EmptyRecyclerView
         android:id="@+id/rv_mediaItems"
         android:scrollbars="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <include
-        layout="@layout/phone_view_progress" />
+    <RelativeLayout
+        android:id="@+id/media_item_empty_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:orientation="vertical"
+        android:textAlignment="center">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textSize="24sp"
+            android:gravity="center_horizontal|center_vertical"
+            android:text="@string/media_item_empty_list" />
+
+        <TextView
+            android:id="@+id/hls_only_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="24dp"
+            android:textSize="18sp"
+            android:gravity="center_horizontal"
+            android:layout_alignParentBottom="true"
+            android:text="HLS only filter is enabled" />
+
+    </RelativeLayout>
 
 </FrameLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -180,5 +180,7 @@
     <string name="tv_settings_analytics_title_description"><![CDATA[Annonymous Analytics & Crash Reports will be sent]]></string>
     <string name="tv_settings_recording_title">Recording Settings</string>
     <string name="tv_settings_video_title">Video Settings</string>
+    <string name="hls_only">Show HLS Only</string>
+    <string name="media_item_empty_list">There are no items to display</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,5 +222,10 @@
     <string name="tv_settings_analytics_title_description"><![CDATA[Annonymous Analytics & Crash Reports will be sent]]></string>
     <string name="tv_settings_recording_title">Recording Settings</string>
     <string name="tv_settings_video_title">Video Settings</string>
+    <string name="pref_filter_hls_only_title">Filter recordings and videos</string>
+    <string name="pref_filter_hls_only">Show HLS Only</string>
+    <string name="pref_filter_hls_only_summary_on">Only recordings and videos that are HLS transcoded will be shown</string>
+    <string name="pref_filter_hls_only_summary_off">All recordings and videos will be shown</string>
+    <string name="media_item_empty_list">There are no items to display</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,6 +58,18 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/pref_filter_hls_only_title">
+
+        <CheckBoxPreference
+            android:title="@string/pref_filter_hls_only"
+            android:key="filter_hls_only"
+            android:defaultValue="false"
+            android:summaryOn="@string/pref_filter_hls_only_summary_on"
+            android:summaryOff="@string/pref_filter_hls_only_summary_off" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/recording_preferences"
         android:key="pref_recording_preferences">
 


### PR DESCRIPTION
This preference allows only HLS transcoded recordings and videos to be displayed in the app. A new empty view was also added to indicate when a category or fragment has no items to display.  It will also indicate it is empty if the HLS only preference has been enabled.

Closes #203